### PR TITLE
avoid vcs option in order to be go version agnostic after go 1.16

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -75,7 +75,6 @@
             "request": "launch",
             "mode": "debug",
             "preLaunchTask": "01 - remove test main.go",
-            "postDebugTask": "01 - remove .git dir in test",
             "cwd": "${workspaceFolder}/test/go/models",
             "program": "${workspaceFolder}/go/cmd/gongc",
             "args": []
@@ -86,7 +85,6 @@
             "request": "launch",
             "mode": "debug",
             "preLaunchTask": "01 - remove test main.go",
-            "postDebugTask": "01 - remove .git dir in test",
             "cwd": "${workspaceFolder}/test/go/models",
             "program": "${workspaceFolder}/go/cmd/gongc",
             "args": [
@@ -99,7 +97,6 @@
             "request": "launch",
             "mode": "debug",
             "preLaunchTask": "01 - remove test main.go",
-            "postDebugTask": "01 - remove .git dir in test",
             "cwd": "${workspaceFolder}/test/go/models",
             "program": "${workspaceFolder}/go/cmd/gongc",
             "args": [
@@ -126,7 +123,6 @@
             "mode": "debug",
             "cwd": "${workspaceFolder}/test2/go/models",
             "program": "${workspaceFolder}/go/cmd/gongc",
-            "postDebugTask": "01 - remove .git dir in test2",
             "args": []
         },
         {
@@ -155,7 +151,6 @@
             "request": "launch",
             "mode": "debug",
             "preLaunchTask": "01 - remove test main.go",
-            "postDebugTask": "01 - remove .git dir in test",
             "cwd": "${workspaceFolder}/test/go/models",
             "program": "${workspaceFolder}/go/cmd/gongc",
             "args": [
@@ -169,7 +164,6 @@
             "request": "launch",
             "mode": "debug",
             "cwd": "${workspaceFolder}/test2/go/models",
-            "postDebugTask": "01 - remove .git dir in test2",
             "program": "${workspaceFolder}/go/cmd/gongc",
             "args": [
                 "-backendOnly"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -144,33 +144,6 @@
                 "main.go"
             ]
         },
-        // remove .dir otherwise, gopls with fire a error "obtaining VCS status"
-        {
-            "label": "01 - remove .git dir in test",
-            "type": "shell",
-            "options": {
-                "cwd": "${workspaceFolder}/test",
-            },
-            "command": "rm",
-            "group": "build",
-            "args": [
-                "-rf",
-                ".git"
-            ]
-        },
-        {
-            "label": "01 - remove .git dir in test2",
-            "type": "shell",
-            "options": {
-                "cwd": "${workspaceFolder}/test/go/cmd/test2",
-            },
-            "command": "rm",
-            "group": "build",
-            "args": [
-                "-rf",
-                ".git"
-            ]
-        },
         {
             "label": "01 - gongc test",
             "type": "shell",

--- a/go/cmd/gongc/main.go
+++ b/go/cmd/gongc/main.go
@@ -131,20 +131,23 @@ func main() {
 		}
 	}
 
-	// check existance of .git directory. If absent, use "ngit init"
+	// check wether one is in a git managed directory. If absent, use "git init"
 	{
+		gitStatusCommand := exec.Command("git", "status")
 
-		gitDirPath := filepath.Join(*pkgPath, "../../.git")
+		var isGitActive bool
 
-		gitDirAbsPath, err := filepath.Abs(gitDirPath)
-		if err != nil {
-			log.Panic("Problem with frontend target path " + err.Error())
+		// Execute the command
+		if err := gitStatusCommand.Run(); err != nil {
+			isGitActive = false
+			log.Println("not a git directory")
+		} else {
+			isGitActive = true
+			log.Println("a git directory")
 		}
-		_, errStat := os.Stat(gitDirAbsPath)
-		log.Println("git directry abs path " + gitDirAbsPath)
 
-		if os.IsNotExist(errStat) {
-			log.Printf("git dir %s does not exist, hence gong is generating it with git init command", gitDirAbsPath)
+		if !isGitActive {
+			log.Printf("git is not active, hence gong is generating a git directory with git init command")
 
 			// git init
 			cmd := exec.Command("git", "init")
@@ -921,7 +924,7 @@ func main() {
 	// go build
 	if true {
 		start := time.Now()
-		cmd := exec.Command("go", "build", "-buildvcs=false")
+		cmd := exec.Command("go", "build")
 		cmd.Dir, _ = filepath.Abs(filepath.Join(*pkgPath, fmt.Sprintf("../cmd/%s", computePkgName())))
 		log.Printf("Running %s command in directory %s and waiting for it to finish...\n", cmd.Args, cmd.Dir)
 


### PR DESCRIPTION
Fixes #152